### PR TITLE
 feat: use @grpc/proto-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@google-cloud/common": "^0.18.9",
+    "@grpc/proto-loader": "^0.1.0",
     "dot-prop": "^4.2.0",
     "duplexify": "^3.6.0",
     "extend": "^3.0.1",

--- a/src/service.ts
+++ b/src/service.ts
@@ -54,12 +54,6 @@ export interface GrpcServiceConfig extends ServiceConfig {
 }
 
 /**
- * @const - A cache of proto objects.
- * @private
- */
-const protoObjectCache: { [name: string]: PackageDefinition } = {};
-
-/**
  * @const {object} - A map of protobuf codes to HTTP status codes.
  * @private
  */
@@ -324,9 +318,12 @@ export class GrpcService extends Service {
   activeServiceMap_ = new Map();
   protos = {};
 
-  static GRPC_SERVICE_OPTIONS = GRPC_SERVICE_OPTIONS;
-  static GRPC_ERROR_CODE_TO_HTTP = GRPC_ERROR_CODE_TO_HTTP;
-  static ObjectToStructConverter = ObjectToStructConverter;
+  /** A cache for proto objects. */
+  private static protoObjectCache: { [name: string]: PackageDefinition } = {};
+
+  static readonly GRPC_SERVICE_OPTIONS = GRPC_SERVICE_OPTIONS;
+  static readonly GRPC_ERROR_CODE_TO_HTTP = GRPC_ERROR_CODE_TO_HTTP;
+  static readonly ObjectToStructConverter = ObjectToStructConverter;
 
   /**
    * Service is a base class, meant to be inherited from by a "service," like
@@ -936,7 +933,7 @@ export class GrpcService extends Service {
       protoPath
     ].join('$');
 
-    if (!protoObjectCache[protoObjectCacheKey]) {
+    if (!GrpcService.protoObjectCache[protoObjectCacheKey]) {
       const services = loadSync(protoPath, {
         keepCase: false,
         defaults: true,
@@ -946,10 +943,10 @@ export class GrpcService extends Service {
         oneofs: true,
         includeDirs: [config.protosDir]
       });
-      protoObjectCache[protoObjectCacheKey] = services;
+      GrpcService.protoObjectCache[protoObjectCacheKey] = services;
     }
 
-    return protoObjectCache[protoObjectCacheKey];
+    return GrpcService.protoObjectCache[protoObjectCacheKey];
   }
 
   /**

--- a/test/service.ts
+++ b/test/service.ts
@@ -1619,11 +1619,11 @@ describe('GrpcService', () => {
     it('should get credentials from the auth client', done => {
       grpcService.authClient = {
         async getClient() {
-          done();
+          return '';
         },
       };
 
-      grpcService.getGrpcCredentials_(assert.ifError);
+      grpcService.getGrpcCredentials_(done);
     });
 
     describe('credential fetching error', () => {

--- a/test/service.ts
+++ b/test/service.ts
@@ -157,6 +157,9 @@ describe('GrpcService', () => {
 
   afterEach(() => {
     grpcProtoLoadOverride = null;
+    // Clear the proto object cache, to ensure that state isn't being carried
+    // across tests.
+    GrpcService['protoObjectCache'] = {};
     sinon.restore();
   });
 


### PR DESCRIPTION
This PR does something similar as https://github.com/googleapis/gax-nodejs/pull/229 but for this codebase.

This is possibly a breaking change because the shape of objects returned by `grpcProtoLoader.loadSync` is different than those returned by `grpc.load`. I've tried preserving behavior as best as possible otherwise.

One thing that is clearly different is that `loadProtoFile` now returns the services defined in a file rather than a specific service. I changed the name (to remove the trailing underscore) since it's already private -- though I didn't change it more liberally because arguably it was a misnomer before, and it is less of a misnomer now.

I tested this with `@google-cloud/spanner` and `@google-cloud/firestore` and the system tests seem to work. I am not aware of any other dependencies that use `GrpcService`.