### PR TITLE
ObjectToStructConverter: handle host objects

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -215,7 +215,7 @@ export class ObjectToStructConverter {
     this.seenObjects.add(obj);
 
     for (const prop in obj) {
-      if (obj.hasOwnProperty(prop)) {
+      if (Object.prototype.hasOwnProperty.call(obj, prop)) {
         const value = obj[prop];
 
         if (is.undefined(value)) {

--- a/test/service.ts
+++ b/test/service.ts
@@ -1919,6 +1919,16 @@ describe('GrpcService', () => {
         assert.strictEqual(struct.fields.a, convertedValue);
       });
 
+      it('should support host objects', () => {
+        const hostObject = { hasOwnProperty: null };
+
+        objectToStructConverter.encodeValue_ = util.noop;
+
+        assert.doesNotThrow(() => {
+          objectToStructConverter.convert(hostObject);
+        });
+      });
+
       it('should not include undefined values', done => {
         objectToStructConverter.encodeValue_ = () => {
           done(new Error('Should not be called'));


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-logging/issues/178
Fixes https://github.com/googleapis/gax-nodejs/issues/164

This allows host objects, which aren't native Objects, to be treated as other objects.