### PR TITLE
chore(build): target es6 with TypeScript build

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,10 @@
     "sinon": "^7.0.0",
     "source-map-support": "^0.5.6",
     "typescript": "~3.1.0"
+  },
+  "nyc": {
+    "exclude": [
+      "build/test"
+    ]
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
+--require source-map-support/register
 --require intelli-espower-loader
 --timeout 10000
---require source-map-support/register
 --throw-deprecation

--- a/test/service.ts
+++ b/test/service.ts
@@ -324,7 +324,7 @@ describe('GrpcService', () => {
         add(prop, val) {
           this[prop] = val;
         }
-      }
+      };
 
       const fakeGrpcMetadata = Object.assign(
           new GrpcMetadataOverride(),
@@ -471,7 +471,8 @@ describe('GrpcService', () => {
           },
         };
       });
-      assert.strictEqual(GrpcService.objToStruct_(obj, options), convertedObject);
+      assert.strictEqual(
+          GrpcService.objToStruct_(obj, options), convertedObject);
     });
   });
 
@@ -1799,20 +1800,20 @@ describe('GrpcService', () => {
       grpcService.protos = {
         Service: {
           Service: class Service {
-          constructor(baseUrl, grpcCredentials, userAgent) {
-            assert.strictEqual(baseUrl, grpcService.baseUrl);
-            assert.strictEqual(grpcCredentials, grpcService.grpcCredentials);
-            assert.deepStrictEqual(
-                userAgent,
-                extend(
-                    {
-                      'grpc.primary_user_agent': grpcService.userAgent,
-                    },
-                    GrpcService.GRPC_SERVICE_OPTIONS));
+            constructor(baseUrl, grpcCredentials, userAgent) {
+              assert.strictEqual(baseUrl, grpcService.baseUrl);
+              assert.strictEqual(grpcCredentials, grpcService.grpcCredentials);
+              assert.deepStrictEqual(
+                  userAgent,
+                  extend(
+                      {
+                        'grpc.primary_user_agent': grpcService.userAgent,
+                      },
+                      GrpcService.GRPC_SERVICE_OPTIONS));
 
-            return fakeService;
+              return fakeService;
+            }
           }
-        }
         },
       };
 
@@ -1850,7 +1851,7 @@ describe('GrpcService', () => {
       grpcService.protos = {
         Service: {
           baseUrl: fakeBaseUrl,
-          Service: class Service {
+          Service: class Service{
             constructor(baseUrl) {
               assert.strictEqual(baseUrl, fakeBaseUrl);
               return fakeService;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
     "rootDir": ".",
     "outDir": "build",
     "noImplicitAny": false,
-    "noImplicitThis": false,
-    "target": "es5"
+    "noImplicitThis": false
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
This change was way more interesting than I was hoping it would be.  This is one of the last modules we had still using `target: es5`.  Had to make some changes to the way we stub things.  Pretty sure all of the actual changes are in tests. 