### PR TITLE
fix: enable noImplicitAny

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -52,6 +52,8 @@ export interface GrpcServiceConfig extends ServiceConfig {
   customEndpoint: boolean;
 }
 
+// TODO: convert this object to an array
+
 /**
  * @const {object} - A map of protobuf codes to HTTP status codes.
  * @private


### PR DESCRIPTION
This is a little dirty, and could be better.  That having been said, it should fix the issues we're seeing in logging / spanner around skipLibCheck. 