### PR TITLE
Release @google-cloud/common-grpc v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [1]: https://www.npmjs.com/package/nodejs-common-grpc?activeTab=versions
 
+## v0.9.2
+
+### Bug fixes
+- fix: add typing for ignored request methods ([#149](https://github.com/googleapis/nodejs-common-grpc/pull/149))
+
 ## v0.9.1
 
 This patch release includes a variety of TypeScript type fixes.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/common-grpc",
   "description": "Common components for Cloud APIs Node.js Client Libraries that require gRPC",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -11,7 +11,7 @@
     "test": "mocha system-test"
   },
   "dependencies": {
-    "@google-cloud/common-grpc": "^0.9.1"
+    "@google-cloud/common-grpc": "^0.9.2"
   },
   "devDependencies": {
     "mocha": "^5.2.0"


### PR DESCRIPTION
This pull request was generated using releasetool.