### PR TITLE
chore: remove usage of through

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,10 @@
     "extend": "^3.0.2",
     "grpc": "^1.15.1",
     "is": "^3.2.1",
-    "retry-request": "^4.0.0",
-    "through2": "^3.0.0"
+    "retry-request": "^4.0.0"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.7",
-    "@types/dot-prop": "^4.2.0",
     "@types/duplexify": "^3.5.0",
     "@types/extend": "^3.0.0",
     "@types/is": "^0.0.21",
@@ -53,17 +51,16 @@
     "@types/proxyquire": "^1.3.28",
     "@types/request": "^2.47.1",
     "@types/sinon": "^7.0.0",
-    "@types/through2": "^2.0.33",
     "codecov": "^3.0.4",
     "gts": "^1.0.0",
     "intelli-espower-loader": "^1.0.1",
-    "mocha": "^6.0.0",
+    "linkinator": "^1.1.2",
+    "mocha": "^6.1.4",
     "nyc": "^14.0.0",
     "power-assert": "^1.6.0",
     "proxyquire": "^2.0.1",
     "sinon": "^7.0.0",
     "source-map-support": "^0.5.6",
-    "typescript": "~3.4.0",
-    "linkinator": "^1.1.2"
+    "typescript": "~3.4.0"
   }
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -39,8 +39,7 @@ import * as grpc from 'grpc';
 import * as is from 'is';
 import * as r from 'request';
 import * as retryRequest from 'retry-request';
-import {Duplex} from 'stream';
-import * as through from 'through2';
+import {Duplex, PassThrough} from 'stream';
 
 export interface ServiceRequestCallback {
   (err: Error | null, apiResponse?: r.Response): void;
@@ -571,13 +570,13 @@ export class GrpcService extends Service {
      * Hence the weird casting below.
      */
     if (global['GCLOUD_SANDBOX_ENV']) {
-      return through.obj();
+      return new PassThrough({objectMode: true});
     }
     const protoOpts = pOpts as ProtoOpts;
     let reqOpts = rOpts as DecorateRequestOptions;
 
     if (!protoOpts.stream) {
-      protoOpts.stream = through.obj();
+      protoOpts.stream = new PassThrough({objectMode: true});
     }
 
     const stream = protoOpts.stream;

--- a/test/service.ts
+++ b/test/service.ts
@@ -25,7 +25,7 @@ import * as is from 'is';
 import * as proxyquire from 'proxyquire';
 import * as retryRequest from 'retry-request';
 import * as sn from 'sinon';
-import * as through from 'through2';
+import {PassThrough} from 'stream';
 
 const sinon = sn.createSandbox();
 const glob = (global as {}) as {GCLOUD_SANDBOX_ENV: boolean | {}};
@@ -893,7 +893,7 @@ describe('GrpcService', () => {
         return new ProtoService();
       };
 
-      fakeStream = through.obj();
+      fakeStream = new PassThrough({objectMode: true});
       retryRequestOverride = () => {
         return fakeStream;
       };
@@ -983,7 +983,7 @@ describe('GrpcService', () => {
         GrpcService.createDeadline_ = createDeadline;
         setImmediate(done);
 
-        return through.obj();
+        return new PassThrough({objectMode: true});
       };
 
       retryRequestOverride = (_, retryOpts) => {
@@ -997,7 +997,7 @@ describe('GrpcService', () => {
       ProtoService.prototype.method = (reqOpts, metadata) => {
         assert.strictEqual(metadata, grpcService.grpcMetadata);
         setImmediate(done);
-        return through.obj();
+        return new PassThrough({objectMode: true});
       };
 
       retryRequestOverride = (_, retryOpts) => {
@@ -1010,7 +1010,7 @@ describe('GrpcService', () => {
     describe('request option decoration', () => {
       beforeEach(() => {
         ProtoService.prototype.method = () => {
-          return through.obj();
+          return new PassThrough({objectMode: true});
         };
 
         retryRequestOverride = (reqOpts, options) => {
@@ -1030,7 +1030,7 @@ describe('GrpcService', () => {
           ProtoService.prototype.method = reqOpts => {
             assert.strictEqual(reqOpts, decoratedRequest);
             setImmediate(done);
-            return through.obj();
+            return new PassThrough({objectMode: true});
           };
 
           grpcService
@@ -1062,7 +1062,7 @@ describe('GrpcService', () => {
 
       beforeEach(() => {
         retryRequestReqOpts = retryRequestOptions = null;
-        retryStream = through.obj();
+        retryStream = new PassThrough({objectMode: true});
 
         retryRequestOverride = (reqOpts, options) => {
           retryRequestReqOpts = reqOpts;
@@ -1096,7 +1096,7 @@ describe('GrpcService', () => {
       });
 
       it('should emit the metadata event as a response event', done => {
-        const fakeStream = through.obj();
+        const fakeStream = new PassThrough({objectMode: true});
 
         ProtoService.prototype.method = () => {
           return fakeStream;
@@ -1202,7 +1202,7 @@ describe('GrpcService', () => {
         GrpcService.createDeadline_ = createDeadline;
         setImmediate(done);
 
-        return through.obj();
+        return new PassThrough({objectMode: true});
       };
 
       retryRequestOverride = (_, retryOpts) => {
@@ -1216,7 +1216,7 @@ describe('GrpcService', () => {
       ProtoService.prototype.method = (reqOpts, metadata) => {
         assert.strictEqual(metadata, grpcService.grpcMetadata);
         setImmediate(done);
-        return through.obj();
+        return new PassThrough({objectMode: true});
       };
 
       retryRequestOverride = (_, retryOpts) => {
@@ -1281,7 +1281,7 @@ describe('GrpcService', () => {
     describe('request option decoration', () => {
       beforeEach(() => {
         ProtoService.prototype.method = () => {
-          return through.obj();
+          return new PassThrough({objectMode: true});
         };
 
         retryRequestOverride = (reqOpts, options) => {
@@ -1301,7 +1301,7 @@ describe('GrpcService', () => {
           ProtoService.prototype.method = reqOpts => {
             assert.strictEqual(reqOpts, decoratedRequest);
             setImmediate(done);
-            return through.obj();
+            return new PassThrough({objectMode: true});
           };
 
           grpcService.requestWritableStream(PROTO_OPTS, REQ_OPTS);


### PR DESCRIPTION
This removes the usage of `through2`, and unused `@types` packages.