### PR TITLE
fix!: upgrade to grpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "@google-cloud/common": "^1.0.0",
     "@google-cloud/projectify": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",
+    "@grpc/grpc-js": "^0.4.0",
     "@grpc/proto-loader": "^0.5.0",
     "duplexify": "^4.0.0",
     "extend": "^3.0.2",
-    "grpc": "^1.15.1",
     "is": "^3.2.1",
     "retry-request": "^4.0.0",
     "through2": "^3.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 
 import {GrpcOperation} from './operation';
 import {GrpcService} from './service';

--- a/src/service.ts
+++ b/src/service.ts
@@ -35,7 +35,7 @@ import {
 import * as duplexify from 'duplexify';
 import {EventEmitter} from 'events';
 import * as extend from 'extend';
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 import * as is from 'is';
 import * as r from 'request';
 import * as retryRequest from 'retry-request';
@@ -379,7 +379,7 @@ export class GrpcService extends Service {
       [
         'gl-node/' + process.versions.node,
         'gccl/' + config.packageJson.version,
-        'grpc/' + require('grpc/package.json').version,
+        'grpc-js/' + require('@grpc/grpc-js/package.json').version,
       ].join(' ')
     );
 

--- a/test/service.ts
+++ b/test/service.ts
@@ -20,7 +20,7 @@ import * as grpcProtoLoader from '@grpc/proto-loader';
 import * as assert from 'assert';
 import * as duplexify from 'duplexify';
 import * as extend from 'extend';
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 import * as is from 'is';
 import * as proxyquire from 'proxyquire';
 import * as retryRequest from 'retry-request';
@@ -149,7 +149,7 @@ describe('GrpcService', () => {
   const EXPECTED_API_CLIENT_HEADER = [
     'gl-node/' + process.versions.node,
     'gccl/' + CONFIG.packageJson.version,
-    'grpc/' + require('grpc/package.json').version,
+    'grpc-js/' + require('@grpc/grpc-js/package.json').version,
   ].join(' ');
 
   const MOCK_GRPC_API: grpcProtoLoader.PackageDefinition = {

--- a/test/service.ts
+++ b/test/service.ts
@@ -305,44 +305,30 @@ describe('GrpcService', () => {
     it('should set insecure credentials if using customEndpoint', () => {
       const config = Object.assign({}, CONFIG, {customEndpoint: true});
       const grpcService = new GrpcService(config, OPTIONS);
-      assert.strictEqual(grpcService.grpcCredentials.name, 'createInsecure');
+      assert.strictEqual(grpcService.grpcCredentials.constructor.name, 'InsecureChannelCredentialsImpl');
     });
 
     it('should default grpcMetadata to empty metadata', () => {
-      GrpcMetadataOverride = class {
-        add(prop, val) {
-          this[prop] = val;
-        }
-      };
-
-      const fakeGrpcMetadata = Object.assign(new GrpcMetadataOverride(), {
+      const fakeGrpcMetadata = {
         'x-goog-api-client': EXPECTED_API_CLIENT_HEADER,
-      });
+      };
 
       const config = Object.assign({}, CONFIG);
       delete config.grpcMetadata;
 
       const grpcService = new GrpcService(config, OPTIONS);
-      assert.deepStrictEqual(grpcService.grpcMetadata, fakeGrpcMetadata);
+      assert.deepStrictEqual(grpcService.grpcMetadata.getMap(), fakeGrpcMetadata);
     });
 
     it('should create and localize grpcMetadata', () => {
-      GrpcMetadataOverride = class {
-        add(prop, val) {
-          this[prop] = val;
-        }
-      };
-
       const fakeGrpcMetadata = Object.assign(
-        new GrpcMetadataOverride(),
         {
           'x-goog-api-client': EXPECTED_API_CLIENT_HEADER,
         },
         CONFIG.grpcMetadata
       );
-
       const grpcService = new GrpcService(CONFIG, OPTIONS);
-      assert.deepStrictEqual(grpcService.grpcMetadata, fakeGrpcMetadata);
+      assert.deepStrictEqual(grpcService.grpcMetadata.getMap(), fakeGrpcMetadata);
     });
 
     it('should localize maxRetries', () => {
@@ -1682,22 +1668,7 @@ describe('GrpcService', () => {
       it('should return grpcCredentials', done => {
         grpcService.getGrpcCredentials_((err, grpcCredentials) => {
           assert.ifError(err);
-
-          assert.strictEqual(grpcCredentials.name, 'combineChannelCredentials');
-
-          const createSslArg = grpcCredentials.args[0];
-          assert.strictEqual(createSslArg.name, 'createSsl');
-          assert.deepStrictEqual(createSslArg.args.length, 0);
-
-          const createFromGoogleCredentialArg = grpcCredentials.args[1];
-          assert.strictEqual(
-            createFromGoogleCredentialArg.name,
-            'createFromGoogleCredential'
-          );
-          assert.strictEqual(
-            createFromGoogleCredentialArg.args[0],
-            AUTH_CLIENT
-          );
+          assert.strictEqual(grpcCredentials.constructor.name, 'SecureChannelCredentialsImpl');
           done();
         });
       });

--- a/test/service.ts
+++ b/test/service.ts
@@ -305,7 +305,10 @@ describe('GrpcService', () => {
     it('should set insecure credentials if using customEndpoint', () => {
       const config = Object.assign({}, CONFIG, {customEndpoint: true});
       const grpcService = new GrpcService(config, OPTIONS);
-      assert.strictEqual(grpcService.grpcCredentials.constructor.name, 'InsecureChannelCredentialsImpl');
+      assert.strictEqual(
+        grpcService.grpcCredentials.constructor.name,
+        'InsecureChannelCredentialsImpl'
+      );
     });
 
     it('should default grpcMetadata to empty metadata', () => {
@@ -317,7 +320,10 @@ describe('GrpcService', () => {
       delete config.grpcMetadata;
 
       const grpcService = new GrpcService(config, OPTIONS);
-      assert.deepStrictEqual(grpcService.grpcMetadata.getMap(), fakeGrpcMetadata);
+      assert.deepStrictEqual(
+        grpcService.grpcMetadata.getMap(),
+        fakeGrpcMetadata
+      );
     });
 
     it('should create and localize grpcMetadata', () => {
@@ -328,7 +334,10 @@ describe('GrpcService', () => {
         CONFIG.grpcMetadata
       );
       const grpcService = new GrpcService(CONFIG, OPTIONS);
-      assert.deepStrictEqual(grpcService.grpcMetadata.getMap(), fakeGrpcMetadata);
+      assert.deepStrictEqual(
+        grpcService.grpcMetadata.getMap(),
+        fakeGrpcMetadata
+      );
     });
 
     it('should localize maxRetries', () => {
@@ -1668,7 +1677,10 @@ describe('GrpcService', () => {
       it('should return grpcCredentials', done => {
         grpcService.getGrpcCredentials_((err, grpcCredentials) => {
           assert.ifError(err);
-          assert.strictEqual(grpcCredentials.constructor.name, 'SecureChannelCredentialsImpl');
+          assert.strictEqual(
+            grpcCredentials.constructor.name,
+            'SecureChannelCredentialsImpl'
+          );
           done();
         });
       });


### PR DESCRIPTION
BREAKING CHANGE: switches from `grpc` to `@grpc/grpc-js`. `@grpc/grpc-js` is a functionally equivalent pure-JS implementation, but does have some differences in its API surface. Also, `@grpc/grpc-js` requires `http2` support so only works in Node.js v8.9+.