### PR TITLE
feat: allow passing grpc in service constructor

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -62,9 +62,9 @@ interface GrpcOptions {
  */
 export interface GrpcServiceConfig extends ServiceConfig {
   /** gRPC implementation to use. By default, uses `@grpc/grpc-js`. */
-  grpc: typeof grpc;
+  grpc?: typeof grpc;
   /** gRPC version, to send in headers */
-  grpcVersion: string;
+  grpcVersion?: string;
   /** Metadata to send with every request. */
   grpcMetadata: grpc.Metadata;
   /** The root directory where proto files live. */

--- a/src/service.ts
+++ b/src/service.ts
@@ -61,6 +61,10 @@ interface GrpcOptions {
  * Configuration object for GrpcService.
  */
 export interface GrpcServiceConfig extends ServiceConfig {
+  /** gRPC implementation to use. By default, uses `@grpc/grpc-js`. */
+  grpc: typeof grpc;
+  /** gRPC version, to send in headers */
+  grpcVersion: string;
   /** Metadata to send with every request. */
   grpcMetadata: grpc.Metadata;
   /** The root directory where proto files live. */
@@ -329,6 +333,8 @@ export class ObjectToStructConverter {
 }
 
 export class GrpcService extends Service {
+  grpc?: typeof grpc;
+  grpcVersion?: string;
   grpcCredentials?: {};
   grpcMetadata?: {add: Function};
   maxRetries?: number;
@@ -366,22 +372,27 @@ export class GrpcService extends Service {
       // https://github.com/GoogleCloudPlatform/google-cloud-node/pull/1137#issuecomment-193315047
       return global['GCLOUD_SANDBOX_ENV'];
     }
-
+    if (config.grpc) {
+      this.grpc = config.grpc;
+      this.grpcVersion = config.grpcVersion || 'grpc/unknown';
+    } else {
+      this.grpc = grpc;
+      this.grpcVersion =
+        'grpc-js/' + require('@grpc/grpc-js/package.json').version;
+    }
     if (config.customEndpoint) {
-      this.grpcCredentials = grpc.credentials.createInsecure();
+      this.grpcCredentials = this.grpc.credentials.createInsecure();
     }
 
-    this.grpcMetadata = new grpc.Metadata();
-
+    this.grpcMetadata = new this.grpc.Metadata();
     this.grpcMetadata.add(
       'x-goog-api-client',
       [
         'gl-node/' + process.versions.node,
         'gccl/' + config.packageJson.version,
-        'grpc-js/' + require('@grpc/grpc-js/package.json').version,
+        this.grpcVersion,
       ].join(' ')
     );
-
     if (config.grpcMetadata) {
       for (const prop in config.grpcMetadata) {
         if (config.grpcMetadata.hasOwnProperty(prop)) {
@@ -967,9 +978,9 @@ export class GrpcService extends Service {
    */
   private getGrpcCredentials_(callback) {
     this.authClient.getClient().then(client => {
-      const credentials = grpc.credentials.combineChannelCredentials(
-        grpc.credentials.createSsl(),
-        grpc.credentials.createFromGoogleCredential(client)
+      const credentials = this.grpc!.credentials.combineChannelCredentials(
+        this.grpc!.credentials.createSsl(),
+        this.grpc!.credentials.createFromGoogleCredential(client)
       );
       if (!this.projectId || this.projectId === '{{projectId}}') {
         this.projectId = client.projectId!;

--- a/test/service.ts
+++ b/test/service.ts
@@ -183,13 +183,13 @@ describe('GrpcService', () => {
     };
     const grpcService = new GrpcService(
       Object.assign(
-        {grpc: fakeGrpc, grpcVersion: '1.2.3', customEndpoint: 'endpoint'},
+        {grpc: fakeGrpc, grpcVersion: 'grpc-foo/1.2.3', customEndpoint: 'endpoint'},
         CONFIG
       ),
       OPTIONS
     );
     assert.strictEqual(grpcService.grpc, fakeGrpc);
-    assert.strictEqual(grpcService.grpcVersion, '1.2.3');
+    assert.strictEqual(grpcService.grpcVersion, 'grpc-foo/1.2.3');
     assert(metadataUsed > 0);
     assert(credentialsUsed > 0);
   });

--- a/test/service.ts
+++ b/test/service.ts
@@ -164,7 +164,7 @@ describe('GrpcService', () => {
     sinon.restore();
   });
 
-  it('should use grpc from config object', async () => {
+  it('should use grpc from config object', () => {
     let metadataUsed = 0;
     let credentialsUsed = 0;
     class Credentials {
@@ -183,7 +183,11 @@ describe('GrpcService', () => {
     };
     const grpcService = new GrpcService(
       Object.assign(
-        {grpc: fakeGrpc, grpcVersion: 'grpc-foo/1.2.3', customEndpoint: 'endpoint'},
+        {
+          grpc: fakeGrpc,
+          grpcVersion: 'grpc-foo/1.2.3',
+          customEndpoint: 'endpoint',
+        },
         CONFIG
       ),
       OPTIONS
@@ -194,7 +198,22 @@ describe('GrpcService', () => {
     assert(credentialsUsed > 0);
   });
 
-  it('should use @grpc/grpc-js by default', async () => {
+  it('should not use @grpc/grpc-js version if grpc object is passed', () => {
+    class Metadata {
+      add() {}
+    }
+    const fakeGrpc = {
+      Metadata,
+    };
+    const grpcService = new GrpcService(
+      Object.assign({grpc: fakeGrpc}, CONFIG),
+      OPTIONS
+    );
+    assert.strictEqual(grpcService.grpc, fakeGrpc);
+    assert.strictEqual(grpcService.grpcVersion, 'grpc/unknown');
+  });
+
+  it('should use @grpc/grpc-js by default', () => {
     const grpcService = new GrpcService(CONFIG, OPTIONS);
     assert.strictEqual(grpcService.grpcVersion, 'grpc-js/' + grpcJsVersion);
     assert.strictEqual(grpcService.grpc, grpc);

--- a/test/service.ts
+++ b/test/service.ts
@@ -71,35 +71,6 @@ class FakeMetadata {
 // tslint:disable-next-line:variable-name
 let GrpcMetadataOverride;
 let grpcProtoLoadOverride: (typeof grpcProtoLoader.loadSync) | null = null;
-const fakeGrpc = {
-  Metadata: FakeMetadata,
-  credentials: {
-    combineChannelCredentials() {
-      return {
-        name: 'combineChannelCredentials',
-        args: arguments,
-      };
-    },
-    createSsl() {
-      return {
-        name: 'createSsl',
-        args: arguments,
-      };
-    },
-    createFromGoogleCredential() {
-      return {
-        name: 'createFromGoogleCredential',
-        args: arguments,
-      };
-    },
-    createInsecure() {
-      return {
-        name: 'createInsecure',
-        args: arguments,
-      };
-    },
-  },
-};
 
 const fakeGrpcProtoLoader = {
   loadSync(filename: string, options?: grpcProtoLoader.Options) {
@@ -146,10 +117,12 @@ describe('GrpcService', () => {
     maxRetries: 3,
   };
 
+  const grpcJsVersion = require('@grpc/grpc-js/package.json').version;
+
   const EXPECTED_API_CLIENT_HEADER = [
     'gl-node/' + process.versions.node,
     'gccl/' + CONFIG.packageJson.version,
-    'grpc-js/' + require('@grpc/grpc-js/package.json').version,
+    'grpc-js/' + grpcJsVersion,
   ].join(' ');
 
   const MOCK_GRPC_API: grpcProtoLoader.PackageDefinition = {
@@ -162,7 +135,6 @@ describe('GrpcService', () => {
         Service: FakeService,
         util: fakeUtil,
       },
-      grpc: fakeGrpc,
       '@google-cloud/projectify': {
         replaceProjectIdToken: fakeReplaceProjectIdTokenOverride,
       },
@@ -190,6 +162,42 @@ describe('GrpcService', () => {
     // across tests.
     GrpcService['protoObjectCache'] = {};
     sinon.restore();
+  });
+
+  it('should use grpc from config object', async () => {
+    let metadataUsed = 0;
+    let credentialsUsed = 0;
+    class Credentials {
+      createInsecure() {
+        ++credentialsUsed;
+      }
+    }
+    class Metadata {
+      add() {
+        ++metadataUsed;
+      }
+    }
+    const fakeGrpc = {
+      Metadata,
+      credentials: new Credentials(),
+    };
+    const grpcService = new GrpcService(
+      Object.assign(
+        {grpc: fakeGrpc, grpcVersion: '1.2.3', customEndpoint: 'endpoint'},
+        CONFIG
+      ),
+      OPTIONS
+    );
+    assert.strictEqual(grpcService.grpc, fakeGrpc);
+    assert.strictEqual(grpcService.grpcVersion, '1.2.3');
+    assert(metadataUsed > 0);
+    assert(credentialsUsed > 0);
+  });
+
+  it('should use @grpc/grpc-js by default', async () => {
+    const grpcService = new GrpcService(CONFIG, OPTIONS);
+    assert.strictEqual(grpcService.grpcVersion, 'grpc-js/' + grpcJsVersion);
+    assert.strictEqual(grpcService.grpc, grpc);
   });
 
   describe('grpc error to http error map', () => {


### PR DESCRIPTION
This PR prepares us to the Global Switch to `@grpc/grpc-js`. Making it possible to pass another `grpc` implementation for those packages that are not yet ready to switch.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
