### PR TITLE
fix(deps): pin to stable release of grpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@google-cloud/common": "^2.0.0",
     "@google-cloud/projectify": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",
-    "@grpc/grpc-js": "^0.5.0",
+    "@grpc/grpc-js": "0.6.7",
     "@grpc/proto-loader": "^0.5.0",
     "duplexify": "^4.0.0",
     "extend": "^3.0.2",

--- a/test/service.ts
+++ b/test/service.ts
@@ -1706,7 +1706,7 @@ describe('GrpcService', () => {
           assert.ifError(err);
           assert.strictEqual(
             grpcCredentials.constructor.name,
-            'SecureChannelCredentialsImpl'
+            'ComposedChannelCredentialsImpl'
           );
           done();
         });


### PR DESCRIPTION
pins to stable release of `@grpc/grpc-js`.
